### PR TITLE
Updated remoting library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <dependency>
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>remoting</artifactId>
-      <version>1.406</version>
+      <version>2.17</version>
     </dependency>
     <dependency><!-- convenient to be able to see the whole Maven during debugging -->
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
2.17 fixes a critical bug preventing `mvn -f jenkins/test/pom.xml test` from working in JDK 7.
